### PR TITLE
Query by words

### DIFF
--- a/app/src/main/java/rocks/tbog/tblauncher/Behaviour.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/Behaviour.java
@@ -927,6 +927,10 @@ public class Behaviour implements ISearchActivity {
 
         List<? extends EntryItem> entries = provider != null ? provider.getPojos() : null;
         if (entries != null && entries.size() > 0) {
+            // reset relevance. This is normally done by a Searcher.
+            for (EntryItem entry : entries)
+                entry.resetRelevance();
+
 //            // copy list in order to change it
 //            entries = new ArrayList<>(entries);
 //            // remove actions and filters from the result list

--- a/app/src/main/java/rocks/tbog/tblauncher/Behaviour.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/Behaviour.java
@@ -929,7 +929,7 @@ public class Behaviour implements ISearchActivity {
         if (entries != null && entries.size() > 0) {
             // reset relevance. This is normally done by a Searcher.
             for (EntryItem entry : entries)
-                entry.resetRelevance();
+                entry.resetResultInfo();
 
 //            // copy list in order to change it
 //            entries = new ArrayList<>(entries);

--- a/app/src/main/java/rocks/tbog/tblauncher/dataprovider/AppCacheProvider.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/dataprovider/AppCacheProvider.java
@@ -48,7 +48,7 @@ public class AppCacheProvider implements IProvider<AppEntry> {
 
         FuzzyScore fuzzyScore = new FuzzyScore(queryNormalized.codePoints);
 
-        AppProvider.checkAppResults(entries, fuzzyScore, searcher);
+        EntryToResultUtils.tagsCheckResults(entries, fuzzyScore, searcher);
     }
 
     public void reload(boolean cancelCurrentLoadTask) {

--- a/app/src/main/java/rocks/tbog/tblauncher/dataprovider/AppCacheProvider.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/dataprovider/AppCacheProvider.java
@@ -13,7 +13,7 @@ import java.util.concurrent.CountDownLatch;
 import rocks.tbog.tblauncher.entry.AppEntry;
 import rocks.tbog.tblauncher.handler.AppsHandler;
 import rocks.tbog.tblauncher.normalizer.StringNormalizer;
-import rocks.tbog.tblauncher.searcher.Searcher;
+import rocks.tbog.tblauncher.searcher.ISearcher;
 import rocks.tbog.tblauncher.utils.FuzzyScore;
 import rocks.tbog.tblauncher.utils.Timer;
 
@@ -27,7 +27,7 @@ public class AppCacheProvider implements IProvider<AppEntry> {
 
     @WorkerThread
     @Override
-    public void requestResults(String query, Searcher searcher) {
+    public void requestResults(String query, ISearcher searcher) {
         StringNormalizer.Result queryNormalized = StringNormalizer.normalizeWithResult(query, false);
 
         if (queryNormalized.codePoints.length == 0) {

--- a/app/src/main/java/rocks/tbog/tblauncher/dataprovider/AppProvider.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/dataprovider/AppProvider.java
@@ -23,7 +23,7 @@ import rocks.tbog.tblauncher.entry.EntryWithTags;
 import rocks.tbog.tblauncher.loader.LoadAppEntry;
 import rocks.tbog.tblauncher.loader.LoadCacheApps;
 import rocks.tbog.tblauncher.normalizer.StringNormalizer;
-import rocks.tbog.tblauncher.searcher.Searcher;
+import rocks.tbog.tblauncher.searcher.ISearcher;
 import rocks.tbog.tblauncher.utils.FuzzyScore;
 import rocks.tbog.tblauncher.utils.UserHandleCompat;
 
@@ -68,8 +68,8 @@ public class AppProvider extends Provider<AppEntry> {
                 final UserManager manager = (UserManager) context.getSystemService(Context.USER_SERVICE);
                 assert manager != null;
                 PackageAddedRemovedHandler.handleEvent(context,
-                        "android.intent.action.PACKAGE_ADDED",
-                        packageName, new UserHandleCompat(manager.getSerialNumberForUser(user), user), false
+                    "android.intent.action.PACKAGE_ADDED",
+                    packageName, new UserHandleCompat(manager.getSerialNumberForUser(user), user), false
                 );
             }
         }
@@ -80,8 +80,8 @@ public class AppProvider extends Provider<AppEntry> {
                 final UserManager manager = (UserManager) context.getSystemService(Context.USER_SERVICE);
                 assert manager != null;
                 PackageAddedRemovedHandler.handleEvent(context,
-                        "android.intent.action.PACKAGE_ADDED",
-                        packageName, new UserHandleCompat(manager.getSerialNumberForUser(user), user), true
+                    "android.intent.action.PACKAGE_ADDED",
+                    packageName, new UserHandleCompat(manager.getSerialNumberForUser(user), user), true
                 );
             }
         }
@@ -92,8 +92,8 @@ public class AppProvider extends Provider<AppEntry> {
                 final UserManager manager = (UserManager) context.getSystemService(Context.USER_SERVICE);
                 assert manager != null;
                 PackageAddedRemovedHandler.handleEvent(context,
-                        "android.intent.action.PACKAGE_REMOVED",
-                        packageName, new UserHandleCompat(manager.getSerialNumberForUser(user), user), false
+                    "android.intent.action.PACKAGE_REMOVED",
+                    packageName, new UserHandleCompat(manager.getSerialNumberForUser(user), user), false
                 );
             }
         }
@@ -104,8 +104,8 @@ public class AppProvider extends Provider<AppEntry> {
                 final UserManager manager = (UserManager) context.getSystemService(Context.USER_SERVICE);
                 assert manager != null;
                 PackageAddedRemovedHandler.handleEvent(context,
-                        "android.intent.action.MEDIA_MOUNTED",
-                        null, new UserHandleCompat(manager.getSerialNumberForUser(user), user), false
+                    "android.intent.action.MEDIA_MOUNTED",
+                    null, new UserHandleCompat(manager.getSerialNumberForUser(user), user), false
                 );
             }
         }
@@ -116,8 +116,8 @@ public class AppProvider extends Provider<AppEntry> {
                 final UserManager manager = (UserManager) context.getSystemService(Context.USER_SERVICE);
                 assert manager != null;
                 PackageAddedRemovedHandler.handleEvent(context,
-                        "android.intent.action.MEDIA_UNMOUNTED",
-                        null, new UserHandleCompat(manager.getSerialNumberForUser(user), user), false
+                    "android.intent.action.MEDIA_UNMOUNTED",
+                    null, new UserHandleCompat(manager.getSerialNumberForUser(user), user), false
                 );
             }
         }
@@ -201,7 +201,7 @@ public class AppProvider extends Provider<AppEntry> {
 
     @WorkerThread
     @Override
-    public void requestResults(String query, Searcher searcher) {
+    public void requestResults(String query, ISearcher searcher) {
         StringNormalizer.Result queryNormalized = StringNormalizer.normalizeWithResult(query, false);
 
         if (queryNormalized.codePoints.length == 0) {
@@ -214,7 +214,7 @@ public class AppProvider extends Provider<AppEntry> {
     }
 
     @WorkerThread
-    static void checkAppResults(Iterable<AppEntry> pojos, FuzzyScore fuzzyScore, Searcher searcher) {
+    static void checkAppResults(Iterable<AppEntry> pojos, FuzzyScore fuzzyScore, ISearcher searcher) {
         FuzzyScore.MatchInfo matchInfo;
         boolean match;
 

--- a/app/src/main/java/rocks/tbog/tblauncher/dataprovider/CalculatorProvider.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/dataprovider/CalculatorProvider.java
@@ -11,7 +11,7 @@ import rocks.tbog.tblauncher.calculator.Result;
 import rocks.tbog.tblauncher.calculator.ShuntingYard;
 import rocks.tbog.tblauncher.calculator.Tokenizer;
 import rocks.tbog.tblauncher.entry.CalculatorEntry;
-import rocks.tbog.tblauncher.searcher.Searcher;
+import rocks.tbog.tblauncher.searcher.ISearcher;
 
 
 public class CalculatorProvider extends SimpleProvider<CalculatorEntry> {
@@ -28,7 +28,7 @@ public class CalculatorProvider extends SimpleProvider<CalculatorEntry> {
     }
 
     @Override
-    public void requestResults(String query, Searcher searcher) {
+    public void requestResults(String query, ISearcher searcher) {
         String spacelessQuery = query.replaceAll("\\s+", "");
         // Now create matcher object.
         Matcher m = computableRegexp.matcher(spacelessQuery);

--- a/app/src/main/java/rocks/tbog/tblauncher/dataprovider/ContactsProvider.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/dataprovider/ContactsProvider.java
@@ -12,7 +12,7 @@ import rocks.tbog.tblauncher.entry.ContactEntry;
 import rocks.tbog.tblauncher.loader.LoadContactsEntry;
 import rocks.tbog.tblauncher.normalizer.PhoneNormalizer;
 import rocks.tbog.tblauncher.normalizer.StringNormalizer;
-import rocks.tbog.tblauncher.searcher.Searcher;
+import rocks.tbog.tblauncher.searcher.ISearcher;
 import rocks.tbog.tblauncher.utils.FuzzyScore;
 
 public class ContactsProvider extends Provider<ContactEntry> {
@@ -64,7 +64,7 @@ public class ContactsProvider extends Provider<ContactEntry> {
     }
 
     @Override
-    public void requestResults(String query, Searcher searcher) {
+    public void requestResults(String query, ISearcher searcher) {
         StringNormalizer.Result queryNormalized = StringNormalizer.normalizeWithResult(query, false);
 
         if (queryNormalized.codePoints.length == 0) {

--- a/app/src/main/java/rocks/tbog/tblauncher/dataprovider/ContactsProvider.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/dataprovider/ContactsProvider.java
@@ -5,7 +5,10 @@ import android.database.ContentObserver;
 import android.provider.ContactsContract;
 import android.util.Log;
 
+import androidx.annotation.WorkerThread;
 import androidx.preference.PreferenceManager;
+
+import java.util.Collection;
 
 import rocks.tbog.tblauncher.Permission;
 import rocks.tbog.tblauncher.entry.ContactEntry;
@@ -65,43 +68,47 @@ public class ContactsProvider extends Provider<ContactEntry> {
 
     @Override
     public void requestResults(String query, ISearcher searcher) {
-        StringNormalizer.Result queryNormalized = StringNormalizer.normalizeWithResult(query, false);
+        for (ContactEntry pojo : pojos)
+            pojo.resetResultInfo();
 
-        if (queryNormalized.codePoints.length == 0) {
-            return;
-        }
+        EntryToResultUtils.recursiveWordCheck(pojos, query, searcher, ContactsProvider::checkResults, ContactEntry.class);
+    }
 
-        FuzzyScore fuzzyScore = new FuzzyScore(queryNormalized.codePoints);
-        FuzzyScore.MatchInfo matchInfo;
-        boolean match;
+    @WorkerThread
+    public static void checkResults(Collection<ContactEntry> entries, FuzzyScore fuzzyScore, ISearcher searcher) {
+        Log.d(TAG, "checkResults count=" + entries.size() + " " + fuzzyScore);
 
-        for (ContactEntry pojo : pojos) {
-            matchInfo = fuzzyScore.match(pojo.normalizedName.codePoints);
-            match = matchInfo.match;
-            pojo.setRelevance(pojo.normalizedName, matchInfo);
+        for (ContactEntry entry : entries) {
+            FuzzyScore.MatchInfo scoreInfo = fuzzyScore.match(entry.normalizedName.codePoints);
 
-            if (pojo.normalizedNickname != null) {
-                matchInfo = fuzzyScore.match(pojo.normalizedNickname.codePoints);
-                if (matchInfo.match && (!match || matchInfo.score > pojo.getRelevance())) {
-                    match = true;
-                    pojo.setRelevance(pojo.normalizedNickname, matchInfo);
+            StringNormalizer.Result matchedText = entry.normalizedName;
+            FuzzyScore.MatchInfo matchedInfo = FuzzyScore.MatchInfo.copyOrNewInstance(scoreInfo, null);
+
+            if (entry.normalizedNickname != null) {
+                scoreInfo = fuzzyScore.match(entry.normalizedNickname.codePoints);
+                if (scoreInfo.match && (!matchedInfo.match || scoreInfo.score > matchedInfo.score)) {
+                    matchedText = entry.normalizedNickname;
+                    matchedInfo = FuzzyScore.MatchInfo.copyOrNewInstance(scoreInfo, matchedInfo);
+                }
+            }
+            if (!matchedInfo.match && entry.normalizedPhone != null && fuzzyScore.getPatternLength() > 2) {
+                // search for the phone number
+                scoreInfo = fuzzyScore.match(entry.normalizedPhone.codePoints);
+                if (scoreInfo.match && scoreInfo.score > matchedInfo.score) {
+                    matchedText = entry.normalizedPhone;
+                    matchedInfo = FuzzyScore.MatchInfo.copyOrNewInstance(scoreInfo, matchedInfo);
                 }
             }
 
-            if (!match && pojo.normalizedPhone != null && queryNormalized.length() > 2) {
-                // search for the phone number
-                matchInfo = fuzzyScore.match(pojo.normalizedPhone.codePoints);
-                match = matchInfo.match;
-                pojo.setRelevance(pojo.normalizedPhone, matchInfo);
-            }
+            entry.addResultMatch(matchedText, matchedInfo);
 
-            if (match) {
-                int boost = Math.min(30, pojo.getTimesContacted());
-                if (pojo.isStarred()) {
+            if (matchedInfo.match) {
+                int boost = Math.min(30, entry.getTimesContacted());
+                if (entry.isStarred()) {
                     boost += 40;
                 }
-                pojo.boostRelevance(boost);
-                if (!searcher.addResult(pojo))
+                entry.boostRelevance(boost);
+                if (!searcher.addResult(entry))
                     return;
             }
         }

--- a/app/src/main/java/rocks/tbog/tblauncher/dataprovider/DBProvider.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/dataprovider/DBProvider.java
@@ -21,7 +21,7 @@ import rocks.tbog.tblauncher.TBLauncherActivity;
 import rocks.tbog.tblauncher.WorkAsync.AsyncTask;
 import rocks.tbog.tblauncher.WorkAsync.TaskRunner;
 import rocks.tbog.tblauncher.entry.EntryItem;
-import rocks.tbog.tblauncher.searcher.Searcher;
+import rocks.tbog.tblauncher.searcher.ISearcher;
 import rocks.tbog.tblauncher.utils.Timer;
 
 public abstract class DBProvider<T extends EntryItem> implements IProvider<T> {
@@ -37,7 +37,7 @@ public abstract class DBProvider<T extends EntryItem> implements IProvider<T> {
     }
 
     @Override
-    public void requestResults(String s, Searcher searcher) {
+    public void requestResults(String query, ISearcher searcher) {
     }
 
     @Override

--- a/app/src/main/java/rocks/tbog/tblauncher/dataprovider/DialProvider.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/dataprovider/DialProvider.java
@@ -6,7 +6,7 @@ import java.util.regex.Pattern;
 
 import rocks.tbog.tblauncher.entry.ContactEntry;
 import rocks.tbog.tblauncher.entry.DialContactEntry;
-import rocks.tbog.tblauncher.searcher.Searcher;
+import rocks.tbog.tblauncher.searcher.ISearcher;
 
 public class DialProvider extends SimpleProvider<ContactEntry> {
 
@@ -33,7 +33,7 @@ public class DialProvider extends SimpleProvider<ContactEntry> {
     }
 
     @Override
-    public void requestResults(String query, Searcher searcher) {
+    public void requestResults(String query, ISearcher searcher) {
         // Append an item only if query looks like a phone number and device has phone capabilities
         if (phonePattern.matcher(query).find()) {
             searcher.addResult(getResult(query));

--- a/app/src/main/java/rocks/tbog/tblauncher/dataprovider/EntryToResultUtils.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/dataprovider/EntryToResultUtils.java
@@ -1,0 +1,83 @@
+package rocks.tbog.tblauncher.dataprovider;
+
+import android.util.Log;
+
+import androidx.annotation.WorkerThread;
+
+import java.util.Collection;
+
+import rocks.tbog.tblauncher.entry.EntryItem;
+import rocks.tbog.tblauncher.entry.EntryWithTags;
+import rocks.tbog.tblauncher.normalizer.StringNormalizer;
+import rocks.tbog.tblauncher.searcher.ISearcher;
+import rocks.tbog.tblauncher.searcher.ResultBuffer;
+import rocks.tbog.tblauncher.utils.FuzzyScore;
+
+public class EntryToResultUtils {
+    final static String TAG = "E2R";
+
+    interface CheckResults<T> {
+        void checkResults(Collection<T> entries, FuzzyScore fuzzyScore, ISearcher searcher);
+    }
+
+    @WorkerThread
+    public static <T extends EntryItem> void recursiveWordCheck(Collection<T> entries, String query, ISearcher searcher, CheckResults<T> action, Class<T> typeClass) {
+        int pos = query.lastIndexOf(' ');
+        if (pos > 0) {
+            String queryLeft = query.substring(0, pos).trim();
+            String queryRight = query.substring(pos + 1).trim();
+
+            StringNormalizer.Result queryNormalizedRight = StringNormalizer.normalizeWithResult(queryRight, false);
+            if (queryNormalizedRight.codePoints.length > 0) {
+                ResultBuffer<T> buffer = new ResultBuffer<>(searcher.tagsEnabled(), typeClass);
+                recursiveWordCheck(entries, queryLeft, buffer, action, typeClass);
+
+                FuzzyScore fuzzyScoreRight = new FuzzyScore(queryNormalizedRight.codePoints);
+                action.checkResults(buffer.getEntryItems(), fuzzyScoreRight, searcher);
+                return;
+            }
+        }
+
+        StringNormalizer.Result queryNormalized = StringNormalizer.normalizeWithResult(query, false);
+        if (queryNormalized.codePoints.length == 0)
+            return;
+
+        FuzzyScore fuzzyScore = new FuzzyScore(queryNormalized.codePoints);
+        action.checkResults(entries, fuzzyScore, searcher);
+    }
+
+    @WorkerThread
+    public static void tagsCheckResults(Collection<? extends EntryWithTags> entries, FuzzyScore fuzzyScore, ISearcher searcher) {
+        Log.d(TAG, "tagsCheckResults count=" + entries.size() + " " + fuzzyScore);
+
+        for (EntryWithTags entry : entries) {
+            if (entry.isHiddenByUser()) {
+                continue;
+            }
+
+            FuzzyScore.MatchInfo scoreInfo = fuzzyScore.match(entry.normalizedName.codePoints);
+
+            StringNormalizer.Result matchedText = entry.normalizedName;
+            FuzzyScore.MatchInfo matchedInfo = FuzzyScore.MatchInfo.copyOrNewInstance(scoreInfo, null);
+
+            if (searcher.tagsEnabled()) {
+                // check relevance for tags
+                for (EntryWithTags.TagDetails tag : entry.getTags()) {
+                    // fuzzyScore.match will return the same object
+                    scoreInfo = fuzzyScore.match(tag.normalized.codePoints);
+                    if (scoreInfo.match && (!matchedInfo.match || scoreInfo.score > matchedInfo.score)) {
+                        matchedText = tag.normalized;
+                        matchedInfo = FuzzyScore.MatchInfo.copyOrNewInstance(scoreInfo, matchedInfo);
+                    }
+                }
+            }
+
+            entry.addResultMatch(matchedText, matchedInfo);
+
+            if (matchedInfo.match && !searcher.addResult(entry)) {
+                return;
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/rocks/tbog/tblauncher/dataprovider/IProvider.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/dataprovider/IProvider.java
@@ -7,7 +7,7 @@ import androidx.annotation.WorkerThread;
 import java.util.List;
 
 import rocks.tbog.tblauncher.entry.EntryItem;
-import rocks.tbog.tblauncher.searcher.Searcher;
+import rocks.tbog.tblauncher.searcher.ISearcher;
 import rocks.tbog.tblauncher.utils.Timer;
 
 /**
@@ -21,12 +21,11 @@ public interface IProvider<T extends EntryItem> {
 
     /**
      * Post search results for the given query string to the searcher
-     *
-     * @param s        Some string query (usually provided by an user)
+     *  @param query        Some string query (usually provided by the user)
      * @param searcher The receiver of results
      */
     @WorkerThread
-    void requestResults(String s, Searcher searcher);
+    void requestResults(String query, ISearcher searcher);
 
     /**
      * Reload the data stored in this provider

--- a/app/src/main/java/rocks/tbog/tblauncher/dataprovider/SearchProvider.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/dataprovider/SearchProvider.java
@@ -21,7 +21,7 @@ import rocks.tbog.tblauncher.entry.OpenUrlEntry;
 import rocks.tbog.tblauncher.entry.SearchEngineEntry;
 import rocks.tbog.tblauncher.entry.SearchEntry;
 import rocks.tbog.tblauncher.normalizer.StringNormalizer;
-import rocks.tbog.tblauncher.searcher.Searcher;
+import rocks.tbog.tblauncher.searcher.ISearcher;
 import rocks.tbog.tblauncher.utils.FuzzyScore;
 
 public class SearchProvider extends SimpleProvider<SearchEntry> {
@@ -116,8 +116,8 @@ public class SearchProvider extends SimpleProvider<SearchEntry> {
     }
 
     @Override
-    public void requestResults(String s, Searcher searcher) {
-        searcher.addResult(getResults(s).toArray(new SearchEntry[0]));
+    public void requestResults(String query, ISearcher searcher) {
+        searcher.addResult(getResults(query).toArray(new SearchEntry[0]));
     }
 
     @NonNull

--- a/app/src/main/java/rocks/tbog/tblauncher/dataprovider/ShortcutsProvider.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/dataprovider/ShortcutsProvider.java
@@ -28,7 +28,7 @@ import rocks.tbog.tblauncher.entry.EntryWithTags;
 import rocks.tbog.tblauncher.entry.ShortcutEntry;
 import rocks.tbog.tblauncher.loader.LoadShortcutsEntryItem;
 import rocks.tbog.tblauncher.normalizer.StringNormalizer;
-import rocks.tbog.tblauncher.searcher.Searcher;
+import rocks.tbog.tblauncher.searcher.ISearcher;
 import rocks.tbog.tblauncher.shortcut.ShortcutUtil;
 import rocks.tbog.tblauncher.utils.FuzzyScore;
 import rocks.tbog.tblauncher.utils.Utilities;
@@ -213,7 +213,7 @@ public class ShortcutsProvider extends Provider<ShortcutEntry> {
     }
 
     @Override
-    public void requestResults(String query, Searcher searcher) {
+    public void requestResults(String query, ISearcher searcher) {
         StringNormalizer.Result queryNormalized = StringNormalizer.normalizeWithResult(query, false);
 
         if (queryNormalized.codePoints.length == 0) {

--- a/app/src/main/java/rocks/tbog/tblauncher/dataprovider/SimpleProvider.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/dataprovider/SimpleProvider.java
@@ -6,7 +6,7 @@ import androidx.annotation.Nullable;
 import java.util.List;
 
 import rocks.tbog.tblauncher.entry.EntryItem;
-import rocks.tbog.tblauncher.searcher.Searcher;
+import rocks.tbog.tblauncher.searcher.ISearcher;
 import rocks.tbog.tblauncher.utils.Timer;
 
 /**
@@ -17,7 +17,7 @@ import rocks.tbog.tblauncher.utils.Timer;
 public abstract class SimpleProvider<T extends EntryItem> implements IProvider<T> {
 
     @Override
-    public void requestResults(String s, Searcher searcher) {
+    public void requestResults(String query, ISearcher searcher) {
     }
 
     @Override

--- a/app/src/main/java/rocks/tbog/tblauncher/entry/AppEntry.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/entry/AppEntry.java
@@ -216,7 +216,7 @@ public final class AppEntry extends EntryWithTags {
     private void displayGridResult(@NonNull View view, int drawFlags) {
         TextView nameView = view.findViewById(android.R.id.text1);
         if (Utilities.checkFlag(drawFlags, FLAG_DRAW_NAME)) {
-            ResultViewHelper.displayHighlighted(relevanceSource, normalizedName, getName(), relevance, nameView);
+            ResultViewHelper.displayHighlighted(relevance, normalizedName, getName(), nameView);
             nameView.setVisibility(View.VISIBLE);
         } else {
             nameView.setText(getName());
@@ -253,14 +253,14 @@ public final class AppEntry extends EntryWithTags {
         final Context context = view.getContext();
 
         TextView nameView = view.findViewById(R.id.item_app_name);
-        ResultViewHelper.displayHighlighted(relevanceSource, normalizedName, getName(), relevance, nameView);
+        ResultViewHelper.displayHighlighted(relevance, normalizedName, getName(), nameView);
 
         TextView tagsView = view.findViewById(R.id.item_app_tag);
         // Hide tags view if tags are empty
         if (getTags().isEmpty()) {
             tagsView.setVisibility(View.GONE);
-        } else if (ResultViewHelper.displayHighlighted(relevanceSource, getTags(), relevance, tagsView, context)
-                || Utilities.checkFlag(drawFlags, FLAG_DRAW_TAGS)) {
+        } else if (ResultViewHelper.displayHighlighted(relevance, getTags(), tagsView, context)
+            || Utilities.checkFlag(drawFlags, FLAG_DRAW_TAGS)) {
             tagsView.setVisibility(View.VISIBLE);
         } else {
             tagsView.setVisibility(View.GONE);
@@ -537,30 +537,30 @@ public final class AppEntry extends EntryWithTags {
             String msg = context.getResources().getString(R.string.app_rename_confirmation, getName());
             Toast.makeText(context, msg, Toast.LENGTH_SHORT).show();
         })
-                .setTitle(R.string.title_app_rename)
-                .setNeutralButton(R.string.custom_name_set_default, (dialog, which) -> {
-                    Context context = dialog.getContext();
-                    String name = null;
-                    PackageManager pm = context.getPackageManager();
-                    try {
-                        ApplicationInfo applicationInfo = pm.getApplicationInfo(getPackageName(), 0);
-                        name = applicationInfo.loadLabel(pm).toString();
-                    } catch (PackageManager.NameNotFoundException ignored) {
-                    }
-                    if (name != null) {
-                        setName(name);
-                        TBApplication app = TBApplication.getApplication(context);
-                        app.getDataHandler().removeRenameApp(getUserComponentName(), name);
-                        app.behaviour().refreshSearchRecord(AppEntry.this);
+            .setTitle(R.string.title_app_rename)
+            .setNeutralButton(R.string.custom_name_set_default, (dialog, which) -> {
+                Context context = dialog.getContext();
+                String name = null;
+                PackageManager pm = context.getPackageManager();
+                try {
+                    ApplicationInfo applicationInfo = pm.getApplicationInfo(getPackageName(), 0);
+                    name = applicationInfo.loadLabel(pm).toString();
+                } catch (PackageManager.NameNotFoundException ignored) {
+                }
+                if (name != null) {
+                    setName(name);
+                    TBApplication app = TBApplication.getApplication(context);
+                    app.getDataHandler().removeRenameApp(getUserComponentName(), name);
+                    app.behaviour().refreshSearchRecord(AppEntry.this);
 
-                        // Show toast message
-                        String msg = context.getString(R.string.app_rename_confirmation, getName());
-                        Toast.makeText(context, msg, Toast.LENGTH_SHORT).show();
-                    }
+                    // Show toast message
+                    String msg = context.getString(R.string.app_rename_confirmation, getName());
+                    Toast.makeText(context, msg, Toast.LENGTH_SHORT).show();
+                }
 
-                    dialog.dismiss();
-                })
-                .show();
+                dialog.dismiss();
+            })
+            .show();
     }
 
     /**
@@ -583,7 +583,7 @@ public final class AppEntry extends EntryWithTags {
             }, Behaviour.LAUNCH_DELAY);
         } else {
             Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-                    Uri.fromParts("package", getPackageName(), null));
+                Uri.fromParts("package", getPackageName(), null));
             TBApplication.behaviour(context).launchIntent(view, intent);
         }
     }
@@ -614,7 +614,7 @@ public final class AppEntry extends EntryWithTags {
      */
     private void launchUninstall(Context context) {
         Intent intent = new Intent(Intent.ACTION_DELETE,
-                Uri.fromParts("package", getPackageName(), null));
+            Uri.fromParts("package", getPackageName(), null));
         context.startActivity(intent);
     }
 

--- a/app/src/main/java/rocks/tbog/tblauncher/entry/AppEntry.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/entry/AppEntry.java
@@ -130,6 +130,7 @@ public final class AppEntry extends EntryWithTags {
         return componentName.getPackageName();
     }
 
+    @Override
     public boolean isHiddenByUser() {
         return hiddenByUser;
     }

--- a/app/src/main/java/rocks/tbog/tblauncher/entry/ContactEntry.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/entry/ContactEntry.java
@@ -157,7 +157,7 @@ public class ContactEntry extends EntryItem {
         TextView nameView = view.findViewById(android.R.id.text1);
         nameView.setTextColor(UIColors.getResultTextColor(context));
         if (Utilities.checkFlag(drawFlags, FLAG_DRAW_NAME)) {
-            ResultViewHelper.displayHighlighted(relevanceSource, normalizedName, getName(), relevance, nameView);
+            ResultViewHelper.displayHighlighted(relevance, normalizedName, getName(), nameView);
             nameView.setVisibility(View.VISIBLE);
         } else {
             nameView.setText(getName());
@@ -186,14 +186,14 @@ public class ContactEntry extends EntryItem {
         // Contact name
         TextView contactName = view.findViewById(R.id.item_contact_name);
         contactName.setTextColor(UIColors.getResultTextColor(context));
-        ResultViewHelper.displayHighlighted(relevanceSource, normalizedName, getName(), relevance, contactName);
+        ResultViewHelper.displayHighlighted(relevance, normalizedName, getName(), contactName);
 
         // Contact phone
         TextView contactPhone = view.findViewById(R.id.item_contact_phone);
         if (phone != null) {
             contactPhone.setVisibility(View.VISIBLE);
             contactPhone.setTextColor(UIColors.getResultText2Color(context));
-            ResultViewHelper.displayHighlighted(relevanceSource, normalizedPhone, phone, relevance, contactPhone);
+            ResultViewHelper.displayHighlighted(relevance, normalizedPhone, phone, contactPhone);
         } else if (getImData() != null && getImData().label != null) {
             contactPhone.setVisibility(View.VISIBLE);
             contactPhone.setTextColor(UIColors.getResultText2Color(context));
@@ -246,7 +246,7 @@ public class ContactEntry extends EntryItem {
             contactNickname.setVisibility(View.GONE);
         } else {
             contactNickname.setVisibility(View.VISIBLE);
-            ResultViewHelper.displayHighlighted(relevanceSource, normalizedNickname, nickname, relevance, contactNickname);
+            ResultViewHelper.displayHighlighted(relevance, normalizedNickname, nickname, contactNickname);
         }
     }
 

--- a/app/src/main/java/rocks/tbog/tblauncher/entry/EntryItem.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/entry/EntryItem.java
@@ -161,7 +161,7 @@ public abstract class EntryItem {
     }
 
     public void setRelevance(@NonNull StringNormalizer.Result normalizedName, @Nullable FuzzyScore.MatchInfo matchInfo) {
-        relevance.setRelevance(normalizedName, matchInfo);
+        relevance.setMatchInfo(normalizedName, matchInfo);
     }
 
     public void boostRelevance(int boost) {

--- a/app/src/main/java/rocks/tbog/tblauncher/entry/EntryItem.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/entry/EntryItem.java
@@ -156,6 +156,10 @@ public abstract class EntryItem {
         return relevance.getRelevance();
     }
 
+    public void addResultMatch(@NonNull StringNormalizer.Result normalizedName, @Nullable FuzzyScore.MatchInfo matchInfo) {
+        relevance.addMatchInfo(normalizedName, matchInfo);
+    }
+
     public void setRelevance(@NonNull StringNormalizer.Result normalizedName, @Nullable FuzzyScore.MatchInfo matchInfo) {
         relevance.setRelevance(normalizedName, matchInfo);
     }
@@ -164,7 +168,7 @@ public abstract class EntryItem {
         relevance.boostRelevance(boost);
     }
 
-    public void resetRelevance() {
+    public void resetResultInfo() {
         relevance.resetRelevance();
     }
 

--- a/app/src/main/java/rocks/tbog/tblauncher/entry/EntryWithTags.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/entry/EntryWithTags.java
@@ -13,6 +13,10 @@ public abstract class EntryWithTags extends EntryItem {
     // Tags assigned to this pojo
     private final ArraySet<TagDetails> tags = new ArraySet<>(0);
 
+    public boolean isHiddenByUser() {
+        return false;
+    }
+
     public static class TagDetails {
         @NonNull
         public final String name;
@@ -20,8 +24,10 @@ public abstract class EntryWithTags extends EntryItem {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
             TagDetails that = (TagDetails) o;
             return name.equals(that.name);
         }

--- a/app/src/main/java/rocks/tbog/tblauncher/entry/ResultRelevance.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/entry/ResultRelevance.java
@@ -30,7 +30,7 @@ public class ResultRelevance implements Comparable<ResultRelevance> {
         infoList.add(resultInfo);
     }
 
-    public void setRelevance(@NonNull StringNormalizer.Result normalizedName, @Nullable FuzzyScore.MatchInfo matchInfo) {
+    public void setMatchInfo(@NonNull StringNormalizer.Result normalizedName, @Nullable FuzzyScore.MatchInfo matchInfo) {
         resetRelevance();
         addMatchInfo(normalizedName, matchInfo);
     }

--- a/app/src/main/java/rocks/tbog/tblauncher/entry/ResultRelevance.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/entry/ResultRelevance.java
@@ -1,0 +1,49 @@
+package rocks.tbog.tblauncher.entry;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import rocks.tbog.tblauncher.normalizer.StringNormalizer;
+import rocks.tbog.tblauncher.utils.FuzzyScore;
+
+public class ResultRelevance implements Comparable<ResultRelevance> {
+    // How relevant is this record? The higher, the most probable it will be displayed
+    public FuzzyScore.MatchInfo relevance = null;
+    // Pointer to the normalizedName that the above relevance was calculated, used for highlighting
+    public StringNormalizer.Result relevanceSource = null;
+
+    public int getRelevance() {
+        return relevance == null ? 0 : relevance.score;
+    }
+
+    public void setRelevance(@NonNull StringNormalizer.Result normalizedName, @Nullable FuzzyScore.MatchInfo matchInfo) {
+        relevanceSource = normalizedName;
+        relevance = matchInfo != null ? new FuzzyScore.MatchInfo(matchInfo) : new FuzzyScore.MatchInfo();
+    }
+
+    public void boostRelevance(int boost) {
+        if (relevance != null)
+            relevance.score += boost;
+    }
+
+    public void resetRelevance() {
+        this.relevanceSource = null;
+        this.relevance = null;
+    }
+
+    @Override
+    public int compareTo(ResultRelevance o) {
+        int difference = getRelevance() - o.getRelevance();
+        if (difference == 0)
+            if (relevanceSource != null && o.relevanceSource != null)
+                return relevanceSource.compareTo(o.relevanceSource);
+        return difference;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ResultRelevance))
+            return false;
+        return compareTo((ResultRelevance) o) == 0;
+    }
+}

--- a/app/src/main/java/rocks/tbog/tblauncher/entry/ResultRelevance.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/entry/ResultRelevance.java
@@ -3,40 +3,63 @@ package rocks.tbog.tblauncher.entry;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 import rocks.tbog.tblauncher.normalizer.StringNormalizer;
 import rocks.tbog.tblauncher.utils.FuzzyScore;
 
 public class ResultRelevance implements Comparable<ResultRelevance> {
-    // How relevant is this record? The higher, the most probable it will be displayed
-    public FuzzyScore.MatchInfo relevance = null;
-    // Pointer to the normalizedName that the above relevance was calculated, used for highlighting
-    public StringNormalizer.Result relevanceSource = null;
+
+    private final ArrayList<ResultInfo> infoList = new ArrayList<>();
+    private int scoreBoost = 0;
 
     public int getRelevance() {
-        return relevance == null ? 0 : relevance.score;
+        int score = scoreBoost;
+        for (ResultInfo info : infoList)
+            score += info.relevance.score;
+        return score;
+    }
+
+    public void addMatchInfo(@NonNull StringNormalizer.Result matchedText, @Nullable FuzzyScore.MatchInfo matchInfo) {
+        final ResultInfo resultInfo;
+        if (matchInfo == null)
+            resultInfo = new ResultInfo(matchedText, new FuzzyScore.MatchInfo());
+        else
+            resultInfo = new ResultInfo(matchedText, new FuzzyScore.MatchInfo(matchInfo));
+        infoList.add(resultInfo);
     }
 
     public void setRelevance(@NonNull StringNormalizer.Result normalizedName, @Nullable FuzzyScore.MatchInfo matchInfo) {
-        relevanceSource = normalizedName;
-        relevance = matchInfo != null ? new FuzzyScore.MatchInfo(matchInfo) : new FuzzyScore.MatchInfo();
+        resetRelevance();
+        addMatchInfo(normalizedName, matchInfo);
     }
 
     public void boostRelevance(int boost) {
-        if (relevance != null)
-            relevance.score += boost;
+        scoreBoost += boost;
     }
 
     public void resetRelevance() {
-        this.relevanceSource = null;
-        this.relevance = null;
+        infoList.clear();
+        scoreBoost = 0;
+    }
+
+    public Collection<ResultInfo> getInfoList() {
+        return infoList;
     }
 
     @Override
     public int compareTo(ResultRelevance o) {
         int difference = getRelevance() - o.getRelevance();
-        if (difference == 0)
-            if (relevanceSource != null && o.relevanceSource != null)
-                return relevanceSource.compareTo(o.relevanceSource);
+        if (difference == 0) {
+            difference = scoreBoost - o.scoreBoost;
+            if (difference == 0) {
+                StringNormalizer.Result rSource = infoList.size() > 0 ? infoList.get(0).relevanceSource : null;
+                StringNormalizer.Result o_rSource = o.infoList.size() > 0 ? o.infoList.get(0).relevanceSource : null;
+                if (rSource != null && o_rSource != null)
+                    return rSource.compareTo(o_rSource);
+            }
+        }
         return difference;
     }
 
@@ -45,5 +68,20 @@ public class ResultRelevance implements Comparable<ResultRelevance> {
         if (!(o instanceof ResultRelevance))
             return false;
         return compareTo((ResultRelevance) o) == 0;
+    }
+
+    public static class ResultInfo {
+
+        // How relevant is this record? The higher, the most probable it will be displayed
+        @NonNull
+        public final FuzzyScore.MatchInfo relevance;
+        // Pointer to the normalizedName that the above relevance was calculated, used for highlighting
+        @NonNull
+        public final StringNormalizer.Result relevanceSource;
+
+        private ResultInfo(@NonNull StringNormalizer.Result relevanceSource, @NonNull FuzzyScore.MatchInfo relevance) {
+            this.relevance = relevance;
+            this.relevanceSource = relevanceSource;
+        }
     }
 }

--- a/app/src/main/java/rocks/tbog/tblauncher/entry/ShortcutEntry.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/entry/ShortcutEntry.java
@@ -278,7 +278,7 @@ public final class ShortcutEntry extends EntryWithTags {
         TextView nameView = view.findViewById(android.R.id.text1);
         nameView.setTextColor(UIColors.getResultTextColor(context));
         if (Utilities.checkFlag(drawFlags, FLAG_DRAW_NAME)) {
-            ResultViewHelper.displayHighlighted(relevanceSource, normalizedName, getName(), relevance, nameView);
+            ResultViewHelper.displayHighlighted(relevance, normalizedName, getName(), nameView);
             nameView.setVisibility(View.VISIBLE);
         } else {
             nameView.setText(getName());
@@ -310,7 +310,7 @@ public final class ShortcutEntry extends EntryWithTags {
         TextView shortcutName = view.findViewById(R.id.item_app_name);
         shortcutName.setTextColor(UIColors.getResultTextColor(context));
 
-        ResultViewHelper.displayHighlighted(relevanceSource, normalizedName, getName(), relevance, shortcutName);
+        ResultViewHelper.displayHighlighted(relevance, normalizedName, getName(), shortcutName);
 
         TextView tagsView = view.findViewById(R.id.item_app_tag);
         tagsView.setTextColor(UIColors.getResultText2Color(context));
@@ -318,7 +318,7 @@ public final class ShortcutEntry extends EntryWithTags {
         // Hide tags view if tags are empty
         if (getTags().isEmpty()) {
             tagsView.setVisibility(View.GONE);
-        } else if (ResultViewHelper.displayHighlighted(relevanceSource, getTags(), relevance, tagsView, context)
+        } else if (ResultViewHelper.displayHighlighted(relevance, getTags(), tagsView, context)
             || Utilities.checkFlag(drawFlags, FLAG_DRAW_TAGS)) {
             tagsView.setVisibility(View.VISIBLE);
         } else {

--- a/app/src/main/java/rocks/tbog/tblauncher/handler/AppsHandler.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/handler/AppsHandler.java
@@ -144,7 +144,7 @@ public class AppsHandler {
         synchronized (AppsHandler.this) {
             if (mIsLoaded) {
                 for (AppEntry appEntry : mAppsCache.values()) {
-                    appEntry.resetRelevance();
+                    appEntry.resetResultInfo();
                     records.add(appEntry);
                 }
             }

--- a/app/src/main/java/rocks/tbog/tblauncher/normalizer/StringNormalizer.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/normalizer/StringNormalizer.java
@@ -1,7 +1,5 @@
 package rocks.tbog.tblauncher.normalizer;
 
-import androidx.annotation.NonNull;
-
 import java.nio.CharBuffer;
 import java.text.Normalizer;
 import java.util.Arrays;
@@ -45,18 +43,17 @@ public class StringNormalizer {
             String decomposedCharString;
             // Is it within the basic latin range?
             // If so, we can skip the expensive call to Normalizer.normalize
-            if(codepoint < 'z') {
+            if (codepoint < 'z') {
                 // Ascii range, no need to normalize!
                 // Add directly if it's not a dash
                 // (HYPHEN-MINUS is the only character before 'z' in one of the
                 //  NON_SPACING_MARK / COMBINING_SPACING_MARK / DASH_PUNCTUATION
                 //  category, so we can skip the Character.getType() and explicitly check for it)
-                if(codepoint != '-') {
+                if (codepoint != '-') {
                     codePoints.add(makeLowercase ? Character.toLowerCase(codepoint) : codepoint);
                     resultMap.add(i);
                 }
-            }
-            else {
+            } else {
                 // Otherwise, we'll need to normalize the code point to a letter and potential accentuation
                 buffer.put(Character.toChars(codepoint));
                 buffer.flip();
@@ -133,21 +130,23 @@ public class StringNormalizer {
         }
 
         @Override
-        public int compareTo(@NonNull Result that) {
+        public int compareTo(Result that) {
             // this optimization is usually worthwhile, and can always be added
             if (this == that)
                 return 0;
+            if (that == null)
+                return 1;
 
-            int result;
             int minLength = Math.min(this.codePoints.length, that.codePoints.length);
             for (int i = 0; i < minLength; i += 1) {
-                if ((result = Character.toLowerCase(this.codePoints[i]) - Character.toLowerCase(that.codePoints[i])) != 0)
-                    return result;
+                final int cmp = Character.toLowerCase(this.codePoints[i]) - Character.toLowerCase(that.codePoints[i]);
+                if (cmp != 0)
+                    return cmp;
             }
 
             if (this.codePoints.length != that.codePoints.length)
                 return this.codePoints.length - that.codePoints.length;
-            
+
             // equal
             return 0;
         }

--- a/app/src/main/java/rocks/tbog/tblauncher/result/ResultViewHelper.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/result/ResultViewHelper.java
@@ -62,12 +62,44 @@ public final class ResultViewHelper {
 
     public static boolean displayHighlighted(@NonNull ResultRelevance relevance, @NonNull StringNormalizer.Result normText,
                                              @NonNull String text, @NonNull TextView view) {
-        return displayHighlighted(relevance.relevanceSource, normText, text, relevance.relevance, view);
+        for (ResultRelevance.ResultInfo result : relevance.getInfoList()) {
+            if (result.relevance.match && result.relevanceSource.equals(normText)) {
+                int color = UIColors.getResultHighlightColor(view.getContext());
+                view.setText(highlightText(normText, text, result.relevance, color));
+                return true;
+            }
+        }
+        view.setText(text);
+        return false;
     }
 
     public static boolean displayHighlighted(@NonNull ResultRelevance relevance, Iterable<EntryWithTags.TagDetails> tags,
                                              TextView view, Context context) {
-        return displayHighlighted(relevance.relevanceSource, tags, relevance.relevance, view, context);
+        boolean matchFound = false;
+
+        int color = UIColors.getResultHighlightColor(context);
+        SpannableStringBuilder builder = new SpannableStringBuilder();
+        boolean first = true;
+        for (EntryWithTags.TagDetails tag : tags) {
+            if (!first)
+                builder.append(" \u2223 ");
+            first = false;
+            boolean appendTagName = true;
+            for (ResultRelevance.ResultInfo result : relevance.getInfoList()) {
+                if (result.relevance.match && result.relevanceSource.equals(tag.normalized)) {
+                    builder.append(highlightText(tag.normalized, tag.name, result.relevance, color));
+                    appendTagName = false;
+                    matchFound = true;
+                    break;
+                }
+            }
+            if (appendTagName)
+                builder.append(tag.name);
+        }
+
+        view.setText(builder);
+
+        return matchFound;
     }
 
     /**

--- a/app/src/main/java/rocks/tbog/tblauncher/result/ResultViewHelper.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/result/ResultViewHelper.java
@@ -20,7 +20,10 @@ import androidx.annotation.Nullable;
 import androidx.constraintlayout.widget.ConstraintLayout;
 
 import java.lang.reflect.Constructor;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.TreeSet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -46,9 +49,13 @@ public final class ResultViewHelper {
     }
 
     private static SpannableString highlightText(StringNormalizer.Result normalized, String text, FuzzyScore.MatchInfo matchInfo, int color) {
+        return highlightText(normalized, text, matchInfo.getMatchedSequences(), color);
+    }
+
+    private static SpannableString highlightText(StringNormalizer.Result normalized, String text, Iterable<Pair<Integer, Integer>> matchedSequences, int color) {
         SpannableString enriched = new SpannableString(text);
 
-        for (Pair<Integer, Integer> position : matchInfo.getMatchedSequences()) {
+        for (Pair<Integer, Integer> position : matchedSequences) {
             enriched.setSpan(
                 new ForegroundColorSpan(color),
                 normalized.mapPosition(position.first),
@@ -60,78 +67,39 @@ public final class ResultViewHelper {
         return enriched;
     }
 
-    public static boolean displayHighlighted(@NonNull ResultRelevance relevance, @NonNull StringNormalizer.Result normText,
-                                             @NonNull String text, @NonNull TextView view) {
-        for (ResultRelevance.ResultInfo result : relevance.getInfoList()) {
-            if (result.relevance.match && result.relevanceSource.equals(normText)) {
-                int color = UIColors.getResultHighlightColor(view.getContext());
-                view.setText(highlightText(normText, text, result.relevance, color));
-                return true;
-            }
-        }
-        view.setText(text);
-        return false;
-    }
-
-    public static boolean displayHighlighted(@NonNull ResultRelevance relevance, Iterable<EntryWithTags.TagDetails> tags,
-                                             TextView view, Context context) {
-        boolean matchFound = false;
-
-        int color = UIColors.getResultHighlightColor(context);
-        SpannableStringBuilder builder = new SpannableStringBuilder();
-        boolean first = true;
-        for (EntryWithTags.TagDetails tag : tags) {
-            if (!first)
-                builder.append(" \u2223 ");
-            first = false;
-            boolean appendTagName = true;
-            for (ResultRelevance.ResultInfo result : relevance.getInfoList()) {
-                if (result.relevance.match && result.relevanceSource.equals(tag.normalized)) {
-                    builder.append(highlightText(tag.normalized, tag.name, result.relevance, color));
-                    appendTagName = false;
-                    matchFound = true;
-                    break;
-                }
-            }
-            if (appendTagName)
-                builder.append(tag.name);
-        }
-
-        view.setText(builder);
-
-        return matchFound;
-    }
-
     /**
      * Highlight text
      *
-     * @param relevance the mapping and code points of the matched text
-     * @param normText  the mapping and code points of the provided text
+     * @param relevance result match information
+     * @param normText  we'll use this to match the result with the text we try to highlight
      * @param text      provided visible text that may need highlighting
-     * @param matchInfo matched sequences
      * @param view      TextView that gets the text
      * @return if the text got any matches
      */
-    public static boolean displayHighlighted(@Nullable StringNormalizer.Result relevance, StringNormalizer.Result normText,
-                                             String text, @Nullable FuzzyScore.MatchInfo matchInfo,
-                                             TextView view) {
-        if (matchInfo == null || !matchInfo.match || !normText.equals(relevance)) {
+    public static boolean displayHighlighted(@NonNull ResultRelevance relevance, @NonNull StringNormalizer.Result normText,
+                                             @NonNull String text, @NonNull TextView view) {
+        // merge all results that have the same text source
+        TreeSet<Integer> matchedPositions = new TreeSet<>();
+        for (ResultRelevance.ResultInfo result : relevance.getInfoList()) {
+            if (result.relevance.match && result.relevanceSource.equals(normText)) {
+                matchedPositions.addAll(result.relevance.matchedIndices);
+            }
+        }
+        if (matchedPositions.isEmpty()) {
             view.setText(text);
             return false;
         }
 
         int color = UIColors.getResultHighlightColor(view.getContext());
-        view.setText(highlightText(normText, text, matchInfo, color));
-
+        List<Pair<Integer, Integer>> matchedSequences = FuzzyScore.MatchInfo.getMatchedSequences(new ArrayList<>(matchedPositions));
+        view.setText(highlightText(normText, text, matchedSequences, color));
         return true;
     }
 
-    public static boolean displayHighlighted(StringNormalizer.Result normalized, Iterable<EntryWithTags.TagDetails> tags,
-                                             @Nullable FuzzyScore.MatchInfo matchInfo, TextView view, Context context) {
-//        final StringBuilder debug = new StringBuilder();
-//        Printer debugPrint = x -> debug.append(x).append("\n");
+    public static boolean displayHighlighted(@NonNull ResultRelevance relevance, Iterable<EntryWithTags.TagDetails> tags,
+                                             TextView view, Context context) {
         boolean matchFound = false;
-
+        TreeSet<Integer> matchedPositions = new TreeSet<>();
         int color = UIColors.getResultHighlightColor(context);
         SpannableStringBuilder builder = new SpannableStringBuilder();
         boolean first = true;
@@ -139,14 +107,23 @@ public final class ResultViewHelper {
             if (!first)
                 builder.append(" \u2223 ");
             first = false;
-            if (matchInfo != null && matchInfo.match && tag.normalized.equals(normalized)) {
-                builder.append(highlightText(tag.normalized, tag.name, matchInfo, color));
-                matchFound = true;
 
-//                debug.setLength(0);
-//                TextUtils.dumpSpans(builder, debugPrint, "");
-            } else {
+            matchedPositions.clear();
+            // find all matched positions
+            for (ResultRelevance.ResultInfo result : relevance.getInfoList()) {
+                if (result.relevance.match && result.relevanceSource.equals(tag.normalized)) {
+                    matchedPositions.addAll(result.relevance.matchedIndices);
+                    matchFound = true;
+                }
+            }
+
+            if (matchedPositions.isEmpty()) {
+                // no matches found
                 builder.append(tag.name);
+            } else {
+                // highlight found matches
+                List<Pair<Integer, Integer>> matchedSequences = FuzzyScore.MatchInfo.getMatchedSequences(new ArrayList<>(matchedPositions));
+                builder.append(highlightText(tag.normalized, tag.name, matchedSequences, color));
             }
         }
 

--- a/app/src/main/java/rocks/tbog/tblauncher/result/ResultViewHelper.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/result/ResultViewHelper.java
@@ -28,6 +28,7 @@ import rocks.tbog.tblauncher.R;
 import rocks.tbog.tblauncher.TBApplication;
 import rocks.tbog.tblauncher.entry.EntryItem;
 import rocks.tbog.tblauncher.entry.EntryWithTags;
+import rocks.tbog.tblauncher.entry.ResultRelevance;
 import rocks.tbog.tblauncher.normalizer.StringNormalizer;
 import rocks.tbog.tblauncher.utils.FuzzyScore;
 import rocks.tbog.tblauncher.utils.PrefCache;
@@ -57,6 +58,16 @@ public final class ResultViewHelper {
         }
 
         return enriched;
+    }
+
+    public static boolean displayHighlighted(@NonNull ResultRelevance relevance, @NonNull StringNormalizer.Result normText,
+                                             @NonNull String text, @NonNull TextView view) {
+        return displayHighlighted(relevance.relevanceSource, normText, text, relevance.relevance, view);
+    }
+
+    public static boolean displayHighlighted(@NonNull ResultRelevance relevance, Iterable<EntryWithTags.TagDetails> tags,
+                                             TextView view, Context context) {
+        return displayHighlighted(relevance.relevanceSource, tags, relevance.relevance, view, context);
     }
 
     /**
@@ -278,5 +289,4 @@ public final class ResultViewHelper {
         image.setImageResource(drawableId);
         Utilities.startAnimatable(image);
     }
-
 }

--- a/app/src/main/java/rocks/tbog/tblauncher/searcher/ISearcher.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/searcher/ISearcher.java
@@ -1,0 +1,12 @@
+package rocks.tbog.tblauncher.searcher;
+
+import androidx.annotation.WorkerThread;
+
+import rocks.tbog.tblauncher.entry.EntryItem;
+
+public interface ISearcher {
+    @WorkerThread
+    boolean addResult(EntryItem... items);
+
+    boolean tagsEnabled();
+}

--- a/app/src/main/java/rocks/tbog/tblauncher/searcher/ResultBuffer.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/searcher/ResultBuffer.java
@@ -1,0 +1,34 @@
+package rocks.tbog.tblauncher.searcher;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import rocks.tbog.tblauncher.entry.EntryItem;
+
+public class ResultBuffer<T extends EntryItem> implements ISearcher {
+    private final boolean tagsEnabled;
+    private final ArrayList<T> entryItems = new ArrayList<>(0);
+    Class<T> typeClass;
+
+    public ResultBuffer(boolean tagsEnabled, Class<T> typeClass) {
+        this.tagsEnabled = tagsEnabled;
+        this.typeClass = typeClass;
+    }
+
+    public Collection<T> getEntryItems() {
+        return entryItems;
+    }
+
+    @Override
+    public boolean addResult(EntryItem... items) {
+        boolean result = false;
+        for (EntryItem item : items)
+            result |= entryItems.add(typeClass.cast(item));
+        return result;
+    }
+
+    @Override
+    public boolean tagsEnabled() {
+        return tagsEnabled;
+    }
+}

--- a/app/src/main/java/rocks/tbog/tblauncher/searcher/Searcher.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/searcher/Searcher.java
@@ -24,7 +24,7 @@ import rocks.tbog.tblauncher.entry.EntryItem;
 import rocks.tbog.tblauncher.utils.PrefCache;
 import rocks.tbog.tblauncher.utils.Utilities;
 
-public abstract class Searcher extends AsyncTask<Void, Void> {
+public abstract class Searcher extends AsyncTask<Void, Void> implements ISearcher {
     // define a different thread than the default AsyncTask thread or else we will block everything else that uses AsyncTask while we search
     public static final ExecutorService SEARCH_THREAD = Executors.newSingleThreadExecutor();
     protected static final int INITIAL_CAPACITY = 50;
@@ -73,6 +73,7 @@ public abstract class Searcher extends AsyncTask<Void, Void> {
      * This is called from the background thread by the providers
      */
     @WorkerThread
+    @Override
     public boolean addResult(EntryItem... pojos) {
         if (isCancelled())
             return false;
@@ -137,6 +138,7 @@ public abstract class Searcher extends AsyncTask<Void, Void> {
         isRefresh = refresh;
     }
 
+    @Override
     public boolean tagsEnabled() {
         return tagsEnabled;
     }

--- a/app/src/main/java/rocks/tbog/tblauncher/utils/FuzzyScore.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/utils/FuzzyScore.java
@@ -134,6 +134,7 @@ public class FuzzyScore {
      * @param text string where to search
      * @return true if each character in pattern is found sequentially within text
      */
+    @NonNull
     public MatchInfo match(CharSequence text) {
         int idx = 0;
         int idxCodepoint = 0;
@@ -152,6 +153,7 @@ public class FuzzyScore {
      * @param text string converted to codepoints
      * @return true if each character in pattern is found sequentially within text
      */
+    @NonNull
     public MatchInfo match(int[] text) {
         // Loop variables
         int score = 0;
@@ -272,8 +274,8 @@ public class FuzzyScore {
          * higher is better match. Value has no intrinsic meaning. Range varies with pattern.
          * Can only compare scores with same search pattern.
          */
-        public int score;
-        public boolean match;
+        public int score = 0;
+        public boolean match = false;
         final ArrayList<Integer> matchedIndices;
 
         public MatchInfo() {

--- a/app/src/main/java/rocks/tbog/tblauncher/utils/FuzzyScore.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/utils/FuzzyScore.java
@@ -97,6 +97,39 @@ public class FuzzyScore {
         this.unmatched_letter_penalty = unmatched_letter_penalty;
     }
 
+    public static String patternToString(int[] pattern) {
+        if (pattern == null)
+            return "null";
+        int iMax = pattern.length - 1;
+        if (iMax == -1)
+            return "[]";
+
+        StringBuilder b = new StringBuilder();
+        b.append('[');
+        for (int i = 0; ; i++) {
+            b.appendCodePoint(pattern[i]);
+            if (i == iMax)
+                return b.append(']').toString();
+        }
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "FuzzyScore{" +
+            "patternLength=" + patternLength +
+            ", patternChar=" + patternToString(patternChar) +
+            ", patternLower=" + patternToString(patternLower) +
+            ", adjacency_bonus=" + adjacency_bonus +
+            ", separator_bonus=" + separator_bonus +
+            ", camel_bonus=" + camel_bonus +
+            ", leading_letter_penalty=" + leading_letter_penalty +
+            ", max_leading_letter_penalty=" + max_leading_letter_penalty +
+            ", unmatched_letter_penalty=" + unmatched_letter_penalty +
+            ", matchInfo=" + matchInfo +
+            '}';
+    }
+
     /**
      * @param text string where to search
      * @return true if each character in pattern is found sequentially within text
@@ -275,6 +308,16 @@ public class FuzzyScore {
             }
             positions.add(new Pair<>(start, end));
             return positions;
+        }
+
+        @NonNull
+        @Override
+        public String toString() {
+            return "MatchInfo{" +
+                "score=" + score +
+                ", match=" + match +
+                ", matchedIndices=" + matchedIndices +
+                '}';
         }
     }
 }

--- a/app/src/main/java/rocks/tbog/tblauncher/utils/FuzzyScore.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/utils/FuzzyScore.java
@@ -3,6 +3,7 @@ package rocks.tbog.tblauncher.utils;
 import android.util.Pair;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -71,6 +72,10 @@ public class FuzzyScore {
 
     public FuzzyScore(int[] pattern) {
         this(pattern, true);
+    }
+
+    public int getPatternLength() {
+        return patternLength;
     }
 
     public void setAdjacencyBonus(int adjacency_bonus) {
@@ -269,7 +274,7 @@ public class FuzzyScore {
         return matchInfo;
     }
 
-    public static class MatchInfo {
+    public static final class MatchInfo {
         /**
          * higher is better match. Value has no intrinsic meaning. Range varies with pattern.
          * Can only compare scores with same search pattern.
@@ -310,6 +315,19 @@ public class FuzzyScore {
             }
             positions.add(new Pair<>(start, end));
             return positions;
+        }
+
+        public static MatchInfo copyOrNewInstance(@NonNull MatchInfo source, @Nullable MatchInfo destination) {
+            if (destination == null || (destination.matchedIndices == null && source.matchedIndices != null))
+                return new MatchInfo(source);
+            destination.score = source.score;
+            destination.match = source.match;
+            if (destination.matchedIndices != null) {
+                destination.matchedIndices.clear();
+                if (source.matchedIndices != null)
+                    destination.matchedIndices.addAll(source.matchedIndices);
+            }
+            return destination;
         }
 
         @NonNull

--- a/app/src/main/java/rocks/tbog/tblauncher/utils/FuzzyScore.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/utils/FuzzyScore.java
@@ -281,7 +281,7 @@ public class FuzzyScore {
          */
         public int score = 0;
         public boolean match = false;
-        final ArrayList<Integer> matchedIndices;
+        public final ArrayList<Integer> matchedIndices;
 
         public MatchInfo() {
             matchedIndices = null;
@@ -297,19 +297,25 @@ public class FuzzyScore {
             matchedIndices = o.matchedIndices != null ? new ArrayList<>(o.matchedIndices) : null;
         }
 
+        @NonNull
         public List<Pair<Integer, Integer>> getMatchedSequences() {
+            return getMatchedSequences(matchedIndices);
+        }
+
+        @NonNull
+        public static List<Pair<Integer, Integer>> getMatchedSequences(@Nullable List<Integer> matchedIndices) {
             if (matchedIndices == null)
                 return Collections.emptyList();
             // compute pair match indices
-            List<Pair<Integer, Integer>> positions = new ArrayList<>(this.matchedIndices.size());
-            int start = this.matchedIndices.get(0);
+            List<Pair<Integer, Integer>> positions = new ArrayList<>(matchedIndices.size());
+            int start = matchedIndices.get(0);
             int end = start + 1;
-            for (int i = 1; i < this.matchedIndices.size(); i += 1) {
-                if (end == this.matchedIndices.get(i)) {
+            for (int i = 1; i < matchedIndices.size(); i += 1) {
+                if (end == matchedIndices.get(i)) {
                     end += 1;
                 } else {
                     positions.add(new Pair<>(start, end));
-                    start = this.matchedIndices.get(i);
+                    start = matchedIndices.get(i);
                     end = start + 1;
                 }
             }


### PR DESCRIPTION
fix #240

Implementation for "Multiple Tags/Name Search"
The searched text is split by the ' '(space) character into words. An entry must match all the words in order to be a result.
While executing a regular search, as soon as there is a "space" the rest of the line is used to execute a search on the previous results.

* [ ] add preference to disable this behavior