### PR TITLE
add "Make default" context menu option for search engine results

### DIFF
--- a/app/src/main/java/rocks/tbog/tblauncher/entry/SearchEngineEntry.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/entry/SearchEngineEntry.java
@@ -9,11 +9,13 @@ import android.util.Log;
 import android.view.View;
 
 import androidx.annotation.NonNull;
+import androidx.preference.PreferenceManager;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
 import rocks.tbog.tblauncher.R;
+import rocks.tbog.tblauncher.ui.LinearAdapter;
 
 public final class SearchEngineEntry extends UrlEntry {
     public static final String SCHEME = "search-engine://";
@@ -29,6 +31,31 @@ public final class SearchEngineEntry extends UrlEntry {
     @Override
     protected String getResultText(Context context) {
         return String.format(context.getString(R.string.ui_item_search), getName(), query);
+    }
+
+    @Override
+    protected void buildPopupMenuCategory(Context context, @NonNull LinearAdapter adapter, int titleStringId) {
+        if (titleStringId == R.string.popup_title_hist_fav) {
+            String defaultSearchProvider = PreferenceManager
+                .getDefaultSharedPreferences(context)
+                .getString("default-search-provider", "Google");
+            if (!defaultSearchProvider.equals(getName()))
+                adapter.add(new LinearAdapter.Item(context, R.string.search_engine_set_default));
+        }
+        super.buildPopupMenuCategory(context, adapter, titleStringId);
+    }
+
+    @Override
+    protected boolean popupMenuClickHandler(@NonNull View view, @NonNull LinearAdapter.MenuItem item, int stringId, View parentView) {
+        if (stringId == R.string.search_engine_set_default) {
+            PreferenceManager
+                .getDefaultSharedPreferences(view.getContext())
+                .edit()
+                .putString("default-search-provider", getName())
+                .apply();
+            return true;
+        }
+        return super.popupMenuClickHandler(view, item, stringId, parentView);
     }
 
     @Override

--- a/app/src/main/java/rocks/tbog/tblauncher/entry/SearchEntry.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/entry/SearchEntry.java
@@ -94,19 +94,26 @@ public abstract class SearchEntry extends EntryItem {
     protected ListPopup buildPopupMenu(Context context, LinearAdapter adapter, View parentView, int flags) {
         List<ContentLoadHelper.CategoryItem> categoryTitle = PrefCache.getResultPopupOrder(context);
         for (ContentLoadHelper.CategoryItem categoryItem : categoryTitle) {
-            final int titleStringId = categoryItem.textId;
-
-            if (titleStringId == R.string.popup_title_customize) {
-                adapter.add(new LinearAdapter.Item(context, R.string.menu_custom_icon));
-            }
+            int pos = adapter.getCount();
+            buildPopupMenuCategory(context, adapter, categoryItem.textId);
+            if (pos != adapter.getCount())
+                adapter.add(pos, new LinearAdapter.ItemTitle(context, categoryItem.textId));
         }
 
         if (Utilities.checkFlag(flags, LAUNCHED_FROM_QUICK_LIST)) {
             adapter.add(new LinearAdapter.ItemTitle(context, R.string.menu_popup_title_settings));
-            adapter.add(new LinearAdapter.Item(context, R.string.menu_popup_quick_list_customize));
+            buildPopupMenuCategory(context, adapter, R.string.menu_popup_title_settings);
         }
 
         return inflatePopupMenu(context, adapter);
+    }
+
+    protected void buildPopupMenuCategory(Context context, @NonNull LinearAdapter adapter, int titleStringId) {
+        if (titleStringId == R.string.popup_title_customize) {
+            adapter.add(new LinearAdapter.Item(context, R.string.menu_custom_icon));
+        } else if (titleStringId == R.string.menu_popup_title_settings) {
+            adapter.add(new LinearAdapter.Item(context, R.string.menu_popup_quick_list_customize));
+        }
     }
 
     @Override


### PR DESCRIPTION
While we can already set the default search engine from the Options menu at providers, it's a good idea to also have the option in the results long press menu.

fix #312