### PR TITLE
Add search engines grid above results

### DIFF
--- a/app/src/main/java/rocks/tbog/tblauncher/Behaviour.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/Behaviour.java
@@ -66,6 +66,7 @@ import rocks.tbog.tblauncher.entry.StaticEntry;
 import rocks.tbog.tblauncher.handler.DataHandler;
 import rocks.tbog.tblauncher.quicklist.EditQuickListDialog;
 import rocks.tbog.tblauncher.result.CustomRecycleLayoutManager;
+import rocks.tbog.tblauncher.result.ListResultAdapter;
 import rocks.tbog.tblauncher.result.RecycleAdapter;
 import rocks.tbog.tblauncher.result.RecycleScrollListener;
 import rocks.tbog.tblauncher.result.ResultHelper;
@@ -118,6 +119,8 @@ public class Behaviour implements ISearchActivity {
     private View mClearButton;
     private View mMenuButton;
     private TextView mLauncherTime = null;
+
+    private final SearchEngineGrid mSearchEngineGrid = new SearchEngineGrid();
     private final Runnable mUpdateTime = new Runnable() {
         @Override
         public void run() {
@@ -149,6 +152,7 @@ public class Behaviour implements ISearchActivity {
                 String text = s.toString();
                 if (lastText.equals(text))
                     return;
+                mSearchEngineGrid.setQuery(text);
                 if (text == null || text.isEmpty())
                     clearAdapter();
                 else
@@ -239,6 +243,7 @@ public class Behaviour implements ISearchActivity {
     }
 
     private void initResultLayout() {
+        mSearchEngineGrid.initLayout(findViewById(R.id.searchEngines), new ListResultAdapter());
         mResultLayout = inflateViewStub(R.id.resultLayout);
 
         mResultList = mResultLayout.findViewById(R.id.resultList);
@@ -918,6 +923,8 @@ public class Behaviour implements ISearchActivity {
     @Override
     public void clearAdapter() {
         mResultAdapter.clear();
+        mSearchEngineGrid.setQuery(null);
+        mSearchEngineGrid.updateAdapter(mPref);
         TBApplication.quickList(getContext()).adapterCleared();
 
         if (TBApplication.state().isResultListVisible())
@@ -980,6 +987,8 @@ public class Behaviour implements ISearchActivity {
             // Make sure the first item is visible when we search
             mResultList.scrollToFirstItem();
         }
+
+        mSearchEngineGrid.updateAdapter(mPref);
 
         mTBLauncherActivity.quickList.adapterUpdated();
         mClearButton.setVisibility(View.VISIBLE);
@@ -1063,6 +1072,7 @@ public class Behaviour implements ISearchActivity {
         if (mResultLayout.getVisibility() == View.VISIBLE)
             return;
         mResultLayout.setVisibility(View.VISIBLE);
+        mSearchEngineGrid.setVisibility(View.VISIBLE);
         Log.d(TAG, "mResultLayout set VISIBLE (anim " + animate + ")");
         if (animate) {
             TBApplication.state().setResultList(LauncherState.AnimatedVisibility.ANIM_TO_VISIBLE);
@@ -1103,6 +1113,7 @@ public class Behaviour implements ISearchActivity {
                         TBApplication.state().setResultList(LauncherState.AnimatedVisibility.HIDDEN);
                         Log.d(TAG, "mResultLayout set INVISIBLE");
                         mResultLayout.setVisibility(View.INVISIBLE);
+                        mSearchEngineGrid.setVisibility(View.INVISIBLE);
                     }
                 })
                 .start();
@@ -1110,6 +1121,7 @@ public class Behaviour implements ISearchActivity {
             TBApplication.state().setResultList(LauncherState.AnimatedVisibility.HIDDEN);
             Log.d(TAG, "mResultLayout set INVISIBLE");
             mResultLayout.setVisibility(View.INVISIBLE);
+            mSearchEngineGrid.setVisibility(View.INVISIBLE);
         }
     }
 
@@ -1279,8 +1291,12 @@ public class Behaviour implements ISearchActivity {
             if (TBApplication.state().isResultListVisible()) {
                 final Behaviour behaviour = TBApplication.behaviour(ctx);
                 behaviour.mResultLayout.setVisibility(View.INVISIBLE);
+                behaviour.mSearchEngineGrid.setVisibility(View.INVISIBLE);
                 // OnDismiss: We restore mResultLayout visibility
-                dialog.setOnDismissListener(dlg -> behaviour.mResultLayout.setVisibility(View.VISIBLE));
+                dialog.setOnDismissListener(dlg -> {
+                    behaviour.mResultLayout.setVisibility(View.VISIBLE);
+                    behaviour.mSearchEngineGrid.setVisibility(View.VISIBLE);
+                });
             }
         }
 

--- a/app/src/main/java/rocks/tbog/tblauncher/SearchEngineGrid.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/SearchEngineGrid.java
@@ -1,0 +1,97 @@
+package rocks.tbog.tblauncher;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.GridView;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import rocks.tbog.tblauncher.dataprovider.SearchProvider;
+import rocks.tbog.tblauncher.entry.EntryItem;
+import rocks.tbog.tblauncher.result.ListResultAdapter;
+import rocks.tbog.tblauncher.result.ResultHelper;
+import rocks.tbog.tblauncher.searcher.ISearcher;
+import rocks.tbog.tblauncher.ui.ListPopup;
+import rocks.tbog.tblauncher.utils.UISizes;
+
+public class SearchEngineGrid implements ISearcher {
+    private SearchProvider mSearchProvider;
+    private GridView mGridView;
+    private ListResultAdapter mGridAdapter;
+    private String mQuery;
+
+    public void initLayout(GridView gridView, ListResultAdapter gridAdapter) {
+        Context ctx = gridView.getContext();
+        mGridView = gridView;
+        mGridAdapter = gridAdapter;
+        mSearchProvider = new SearchProvider(ctx, true, false);
+
+        gridView.setAdapter(gridAdapter);
+        CustomizeUI.setResultListPref(gridView, true);
+        int columnWidth = UISizes.getResultIconSize(ctx);
+        gridView.setColumnWidth(columnWidth);
+
+        gridView.setOnItemClickListener(this::onItemClick);
+        gridView.setOnItemLongClickListener(this::onItemLongClick);
+    }
+
+    public void setQuery(String query) {
+        mQuery = query;
+    }
+
+    public void setVisibility(int visibility) {
+        mGridView.setVisibility(visibility);
+        if (visibility == View.INVISIBLE && !mGridAdapter.isEmpty()) {
+            mGridAdapter.setItems(Collections.emptyList());
+        }
+    }
+
+    public void updateAdapter(SharedPreferences pref) {
+        if (mQuery == null || mQuery.isEmpty()) {
+            mGridAdapter.setItems(Collections.emptyList());
+            return;
+        }
+        if (pref.getBoolean("search-engine-grid", false)) {
+            mSearchProvider.requestResults(mQuery, this);
+        }
+    }
+
+    @Override
+    public boolean addResult(EntryItem... items) {
+        mGridAdapter.setItems(Arrays.asList(items));
+        mGridView.requestLayout();
+        return false;
+    }
+
+    @Override
+    public boolean tagsEnabled() {
+        return false;
+    }
+
+    private void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+        if (parent.getAdapter() != mGridAdapter)
+            return;
+        var result = mGridAdapter.getItem(position);
+        ResultHelper.launch(view, result);
+    }
+
+    private boolean onItemLongClick(AdapterView<?> parent, View v, int position, long id) {
+        if (parent.getAdapter() != mGridAdapter)
+            return false;
+
+        var result = mGridAdapter.getItem(position);
+        ListPopup menu = result.getPopupMenu(v);
+
+        // check if menu contains elements and if yes show it
+        if (!menu.getAdapter().isEmpty()) {
+            TBApplication.getApplication(v.getContext()).registerPopup(menu);
+            menu.show(v);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/app/src/main/java/rocks/tbog/tblauncher/handler/DataHandler.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/handler/DataHandler.java
@@ -205,13 +205,15 @@ public class DataHandler extends BroadcastReceiver
     private void toggleableProviders(SharedPreferences prefs) {
         final Context context = getContext();
 
-        // Search engine provider,
+        // Search engine provider. The grid handles the provider autonomously
         {
+            boolean bSearchGrid = prefs.getBoolean("search-engine-grid", false);
+            boolean bSearch = !bSearchGrid && prefs.getBoolean("enable-search", true);
+            boolean bURL = prefs.getBoolean("enable-url", true);
             String providerName = "search";
-            if (prefs.getBoolean("enable-search", true) ||
-                prefs.getBoolean("enable-url", true)) {
+            if (bSearch || bURL) {
                 ProviderEntry providerEntry = new ProviderEntry();
-                providerEntry.provider = new SearchProvider(context, prefs);
+                providerEntry.provider = new SearchProvider(context, bSearch, bURL);
                 providers.put(providerName, providerEntry);
             } else {
                 providers.remove(providerName);

--- a/app/src/main/java/rocks/tbog/tblauncher/result/ListResultAdapter.java
+++ b/app/src/main/java/rocks/tbog/tblauncher/result/ListResultAdapter.java
@@ -1,0 +1,77 @@
+package rocks.tbog.tblauncher.result;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import rocks.tbog.tblauncher.entry.EntryItem;
+
+public class ListResultAdapter extends BaseAdapter {
+    final ArrayList<EntryItem> mList = new ArrayList<>(0);
+    final int mDrawFlags = EntryItem.FLAG_DRAW_GRID | EntryItem.FLAG_DRAW_ICON;
+
+    @Override
+    public int getCount() {
+        return mList.size();
+    }
+
+    @Override
+    public EntryItem getItem(int position) {
+        return mList.get(position);
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return getItem(position).hashCode();
+    }
+
+    @Override
+    public boolean hasStableIds() {
+        return true;
+    }
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        final EntryItem item = getItem(position);
+
+        Context context = parent.getContext();
+        View itemView = convertView;
+        if (itemView == null) {
+            final int viewType = getItemViewType(position);
+            final int layoutRes = ResultHelper.getItemViewLayout(viewType);
+
+            LayoutInflater inflater = LayoutInflater.from(context);
+            itemView = inflater.inflate(layoutRes, parent, false);
+        }
+
+        item.displayResult(itemView, mDrawFlags);
+        return itemView;
+    }
+
+    @Override
+    public int getItemViewType(int position) {
+        final EntryItem item = getItem(position);
+        return ResultHelper.getItemViewType(item, mDrawFlags);
+    }
+
+    @Override
+    public int getViewTypeCount() {
+        return ResultHelper.getItemViewTypeCount();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return getCount() == 0;
+    }
+
+    public void setItems(Collection<EntryItem> list) {
+        mList.clear();
+        mList.addAll(list);
+        notifyDataSetChanged();
+    }
+}

--- a/app/src/main/res/layout/activity_fullscreen.xml
+++ b/app/src/main/res/layout/activity_fullscreen.xml
@@ -69,6 +69,28 @@
             app:barrierDirection="bottom"
             app:constraint_referenced_ids="stubSearchTop,dockAboveResults" />
 
+        <GridView
+            android:id="@+id/searchEngines"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:clipToPadding="false"
+            android:columnWidth="@dimen/icon_size"
+            android:gravity="center"
+            android:horizontalSpacing="@dimen/edit_tag_padding"
+            android:numColumns="auto_fit"
+            android:paddingHorizontal="@dimen/result_margin_horizontal"
+            android:paddingVertical="@dimen/result_margin_vertical"
+            android:stretchMode="columnWidth"
+            android:verticalSpacing="@dimen/edit_tag_padding"
+            android:visibility="invisible"
+            app:layout_constraintBottom_toTopOf="@id/resultLayout"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/barrierTop"
+            tools:itemCount="9"
+            tools:listitem="@layout/item_grid"
+            tools:visibility="visible" />
+
         <rocks.tbog.tblauncher.ui.ViewStubPreview
             android:id="@+id/resultLayout"
             android:layout_width="0dp"
@@ -82,7 +104,7 @@
             app:layout_constraintBottom_toTopOf="@id/barrierFooter"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/barrierTop"
+            app:layout_constraintTop_toBottomOf="@id/searchEngines"
             tools:visibility="visible" />
 
         <rocks.tbog.tblauncher.ui.WidgetLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -232,6 +232,7 @@
     <string name="invalid_rename_search_engine">There is already a \"%s\" search engine</string>
     <string name="provider_section">Providers</string>
     <string name="enable_search">Search engine</string>
+    <string name="search_engine_grid">Search engine grid</string>
     <string name="enable_url">Web URL</string>
     <string name="enable_calculator">Calculator</string>
     <string name="enable_dial">Dial search</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1074,13 +1074,19 @@
 
             <androidx.preference.SwitchPreference
                 android:defaultValue="true"
-                android:dependency="enable-search"
+                android:disableDependentsState="true"
+                android:key="search-engine-grid"
+                android:title="@string/search_engine_grid" />
+
+            <androidx.preference.SwitchPreference
+                android:defaultValue="true"
                 android:key="enable-url"
                 android:title="@string/enable_url" />
 
             <androidx.preference.SwitchPreference
                 android:defaultValue="true"
                 android:key="enable-search"
+                android:dependency="search-engine-grid"
                 android:title="@string/enable_search" />
 
             <rocks.tbog.tblauncher.preference.CustomDialogPreference


### PR DESCRIPTION
Show search engines, since they don't change from search to search so the extra information of the app name is not useful.
fix #339