### PR TITLE
Preference screen dialogs

### DIFF
--- a/app/src/main/java/net/mm2d/color/chooser/element/ColorSliderView.kt
+++ b/app/src/main/java/net/mm2d/color/chooser/element/ColorSliderView.kt
@@ -15,8 +15,9 @@ import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
 import androidx.core.content.withStyledAttributes
-import rocks.tbog.tblauncher.R
 import net.mm2d.color.chooser.util.*
+import rocks.tbog.tblauncher.R
+import kotlin.math.max
 
 internal class ColorSliderView
 @JvmOverloads constructor(
@@ -27,15 +28,16 @@ internal class ColorSliderView
     private val paint = Paint().also {
         it.isAntiAlias = true
     }
-    private val requestPadding = getPixels(R.dimen.mm2d_cc_panel_margin)
-    private val requestWidth = getPixels(R.dimen.mm2d_cc_slider_width) + requestPadding * 2
-    private val requestHeight = getPixels(R.dimen.mm2d_cc_slider_height) + requestPadding * 2
     private val sampleRadius = getDimension(R.dimen.mm2d_cc_sample_radius)
     private val sampleFrameRadius = sampleRadius + getDimension(R.dimen.mm2d_cc_sample_frame)
     private val sampleShadowRadius =
         sampleFrameRadius + getDimension(R.dimen.mm2d_cc_sample_shadow)
     private val frameLineWidth = getDimension(R.dimen.mm2d_cc_sample_frame)
     private val shadowLineWidth = getDimension(R.dimen.mm2d_cc_sample_shadow)
+    private val requestPaddingH = max(getPixels(R.dimen.mm2d_cc_panel_margin), sampleShadowRadius.toInt())
+    private val requestPaddingV = max(getPixels(R.dimen.mm2d_cc_panel_margin), (frameLineWidth * 2 + shadowLineWidth).toInt())
+    private val requestWidth = getPixels(R.dimen.mm2d_cc_slider_width) + requestPaddingH * 2
+    private val requestHeight = getPixels(R.dimen.mm2d_cc_slider_height) + requestPaddingV * 2
     private val gradationRect = Rect(0, 0, RANGE, 1)
     private val targetRect = Rect()
     private val colorSampleFrame = getColor(R.color.mm2d_cc_sample_frame)
@@ -98,10 +100,10 @@ internal class ColorSliderView
 
     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
         targetRect.set(
-            paddingLeft + requestPadding,
-            paddingTop + requestPadding,
-            width - paddingRight - requestPadding,
-            height - paddingBottom - requestPadding
+            paddingLeft + requestPaddingH,
+            paddingTop + requestPaddingV,
+            width - paddingRight - requestPaddingH,
+            height - paddingBottom - requestPaddingV
         )
     }
 

--- a/app/src/main/java/net/mm2d/color/chooser/element/HueView.kt
+++ b/app/src/main/java/net/mm2d/color/chooser/element/HueView.kt
@@ -14,11 +14,11 @@ import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
 import androidx.annotation.ColorInt
-import rocks.tbog.tblauncher.R
 import net.mm2d.color.chooser.util.ColorUtils
 import net.mm2d.color.chooser.util.getColor
 import net.mm2d.color.chooser.util.getDimension
 import net.mm2d.color.chooser.util.getPixels
+import rocks.tbog.tblauncher.R
 import kotlin.math.max
 
 internal class HueView
@@ -31,14 +31,15 @@ internal class HueView
     private var color: Int = Color.RED
     private val paint = Paint()
     private val bitmap: Bitmap = createMaskBitmap()
-    private val requestPadding = getPixels(R.dimen.mm2d_cc_panel_margin)
-    private val requestWidth = getPixels(R.dimen.mm2d_cc_hue_width) + requestPadding * 2
-    private val requestHeight = getPixels(R.dimen.mm2d_cc_hsv_size) + requestPadding * 2
     private val sampleRadius = getDimension(R.dimen.mm2d_cc_sample_radius)
     private val sampleFrameRadius =
         sampleRadius + getDimension(R.dimen.mm2d_cc_sample_frame)
-    private val _sampleShadowRadius =
+    private val sampleShadowRadius =
         sampleFrameRadius + getDimension(R.dimen.mm2d_cc_sample_shadow)
+    private val requestPaddingH = getPixels(R.dimen.mm2d_cc_panel_margin)
+    private val requestPaddingV = max(getPixels(R.dimen.mm2d_cc_panel_margin), sampleShadowRadius.toInt())
+    private val requestWidth = getPixels(R.dimen.mm2d_cc_hue_width) + requestPaddingH * 2
+    private val requestHeight = getPixels(R.dimen.mm2d_cc_hsv_size) + requestPaddingV * 2
     private val bitmapRect = Rect(0, 0, 1, RANGE)
     private val targetRect = Rect()
     private var hue: Float = 0f
@@ -68,10 +69,10 @@ internal class HueView
 
     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
         targetRect.set(
-            paddingLeft + requestPadding,
-            paddingTop + requestPadding,
-            width - paddingRight - requestPadding,
-            height - paddingBottom - requestPadding
+            paddingLeft + requestPaddingH,
+            paddingTop + requestPaddingV,
+            width - paddingRight - requestPaddingH,
+            height - paddingBottom - requestPaddingV
         )
     }
 
@@ -80,7 +81,7 @@ internal class HueView
         val x = targetRect.centerX().toFloat()
         val y = hue * targetRect.height() + targetRect.top
         paint.color = colorSampleShadow
-        canvas.drawCircle(x, y, _sampleShadowRadius, paint)
+        canvas.drawCircle(x, y, sampleShadowRadius, paint)
         paint.color = colorSampleFrame
         canvas.drawCircle(x, y, sampleFrameRadius, paint)
         paint.color = color

--- a/app/src/main/java/net/mm2d/color/chooser/element/SvView.kt
+++ b/app/src/main/java/net/mm2d/color/chooser/element/SvView.kt
@@ -14,11 +14,11 @@ import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
 import androidx.annotation.ColorInt
-import rocks.tbog.tblauncher.R
 import net.mm2d.color.chooser.util.ColorUtils
 import net.mm2d.color.chooser.util.getColor
 import net.mm2d.color.chooser.util.getDimension
 import net.mm2d.color.chooser.util.getPixels
+import rocks.tbog.tblauncher.R
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
@@ -34,13 +34,13 @@ internal class SvView
     private var maxColor: Int = Color.RED
     private var maskBitmap: Bitmap? = null
     private val paint = Paint().also { it.isAntiAlias = true }
-    private val requestPadding = getPixels(R.dimen.mm2d_cc_panel_margin)
-    private val requestWidth = getPixels(R.dimen.mm2d_cc_hsv_size) + requestPadding * 2
-    private val requestHeight = getPixels(R.dimen.mm2d_cc_hsv_size) + requestPadding * 2
     private val sampleRadius = getDimension(R.dimen.mm2d_cc_sample_radius)
     private val sampleFrameRadius = sampleRadius + getDimension(R.dimen.mm2d_cc_sample_frame)
     private val sampleShadowRadius =
         sampleFrameRadius + getDimension(R.dimen.mm2d_cc_sample_shadow)
+    private val requestPadding = max(getPixels(R.dimen.mm2d_cc_panel_margin), sampleShadowRadius.toInt())
+    private val requestWidth = getPixels(R.dimen.mm2d_cc_hsv_size) + requestPadding * 2
+    private val requestHeight = getPixels(R.dimen.mm2d_cc_hsv_size) + requestPadding * 2
     private val maskRect = Rect(0, 0, TONE_SIZE, TONE_SIZE)
     private val targetRect = Rect()
     private var hue: Float = 0f

--- a/app/src/main/res/layout/dialog_preference_color_chooser.xml
+++ b/app/src/main/res/layout/dialog_preference_color_chooser.xml
@@ -7,12 +7,13 @@
 
     <ProgressBar
         android:id="@+id/iconLoadingBar"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="0dp"
         android:indeterminate="true"
         android:indeterminateOnly="true"
         android:visibility="visible"
         app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintBottom_toTopOf="@id/buttonPanel"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/mm2d_cc_view_control.xml
+++ b/app/src/main/res/layout/mm2d_cc_view_control.xml
@@ -1,34 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout"
-    >
+    tools:layout_height="100dp"
+    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
 
     <net.mm2d.color.chooser.element.ColorSliderView
         android:id="@+id/seek_alpha"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/mm2d_cc_page_margin"
-        android:paddingTop="@dimen/mm2d_cc_seek_padding"
-        android:paddingBottom="@dimen/mm2d_cc_seek_padding"
         app:alphaMode="true"
         app:baseColor="#ffffff"
+        app:layout_constraintBottom_toTopOf="@id/color_preview"
         app:layout_constraintEnd_toStartOf="@id/text_alpha"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="spread"
         app:maxColor="#000000"
-        tools:progress="128"
-        />
+        tools:progress="128" />
 
     <TextView
         android:id="@+id/text_alpha"
         android:layout_width="@dimen/mm2d_cc_rgb_size"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
         android:layout_marginEnd="@dimen/mm2d_cc_page_margin"
         android:fontFamily="monospace"
         android:gravity="end"
@@ -39,25 +36,22 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/seek_alpha"
         app:layout_constraintTop_toTopOf="@id/seek_alpha"
-        tools:ignore="HardcodedText,SpUsage"
-        />
+        tools:ignore="HardcodedText,SpUsage" />
 
     <net.mm2d.color.chooser.element.PreviewView
         android:id="@+id/color_preview"
         android:layout_width="@dimen/mm2d_cc_preview_width"
         android:layout_height="@dimen/mm2d_cc_preview_height"
-        android:layout_marginTop="@dimen/mm2d_cc_page_margin"
-        android:layout_marginEnd="@dimen/mm2d_cc_sample_horizontal_margin"
-        android:layout_marginRight="@dimen/mm2d_cc_sample_horizontal_margin"
+        android:layout_marginHorizontal="@dimen/mm2d_cc_sample_horizontal_margin"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/edit_hex"
-        app:layout_constraintTop_toBottomOf="@id/seek_alpha"
-        />
+        app:layout_constraintTop_toBottomOf="@id/seek_alpha" />
 
     <EditText
         android:id="@+id/edit_hex"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/mm2d_cc_page_margin"
+        android:layout_marginHorizontal="@dimen/mm2d_cc_page_margin"
         android:ems="5"
         android:fontFamily="monospace"
         android:inputType="textNoSuggestions"
@@ -65,6 +59,5 @@
         app:layout_constraintBottom_toBottomOf="@id/color_preview"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@id/color_preview"
-        tools:ignore="Autofill,LabelFor,SpUsage"
-        />
+        tools:ignore="Autofill,LabelFor,SpUsage" />
 </merge>

--- a/app/src/main/res/layout/mm2d_cc_view_dialog.xml
+++ b/app/src/main/res/layout/mm2d_cc_view_dialog.xml
@@ -36,9 +36,9 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
-        android:layout_marginTop="@dimen/mm2d_cc_panel_margin"
+        android:layout_marginHorizontal="@dimen/mm2d_cc_panel_margin"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@id/view_pager" />
 </merge>

--- a/app/src/main/res/layout/mm2d_cc_view_hsv.xml
+++ b/app/src/main/res/layout/mm2d_cc_view_hsv.xml
@@ -8,15 +8,6 @@
     tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout"
     >
 
-    <View
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        />
-
     <net.mm2d.color.chooser.element.SvView
         android:id="@+id/sv_view"
         android:layout_width="0dp"

--- a/app/src/main/res/layout/mm2d_cc_view_slider.xml
+++ b/app/src/main/res/layout/mm2d_cc_view_slider.xml
@@ -1,37 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout"
-    >
+    tools:layout_height="130dp"
+    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
 
     <net.mm2d.color.chooser.element.ColorSliderView
         android:id="@+id/seek_red"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/mm2d_cc_page_margin"
-        android:paddingTop="@dimen/mm2d_cc_seek_padding"
-        android:paddingBottom="@dimen/mm2d_cc_seek_padding"
         app:alphaMode="false"
         app:baseColor="#000000"
-        app:layout_constrainedWidth="true"
         app:layout_constraintBottom_toTopOf="@id/seek_green"
         app:layout_constraintEnd_toStartOf="@id/text_red"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_chainStyle="packed"
+        app:layout_constraintVertical_chainStyle="spread"
         app:maxColor="#ff0000"
-        tools:progress="128"
-        />
+        tools:progress="128" />
 
     <TextView
         android:id="@+id/text_red"
         android:layout_width="@dimen/mm2d_cc_rgb_size"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
         android:layout_marginEnd="@dimen/mm2d_cc_page_margin"
         android:fontFamily="monospace"
         android:gravity="end"
@@ -40,27 +34,23 @@
         android:textSize="@dimen/mm2d_cc_color_text"
         app:layout_constraintBottom_toBottomOf="@id/seek_red"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/seek_red"
         app:layout_constraintTop_toTopOf="@id/seek_red"
-        tools:ignore="HardcodedText,SpUsage"
-        />
+        tools:ignore="HardcodedText,SpUsage" />
 
     <net.mm2d.color.chooser.element.ColorSliderView
         android:id="@+id/seek_green"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/mm2d_cc_page_margin"
-        android:paddingTop="@dimen/mm2d_cc_seek_padding"
-        android:paddingBottom="@dimen/mm2d_cc_seek_padding"
         app:alphaMode="false"
         app:baseColor="#000000"
-        app:layout_constrainedWidth="true"
-        app:layout_constraintBottom_toBottomOf="@id/seek_blue"
+        app:layout_constraintBottom_toTopOf="@id/seek_blue"
         app:layout_constraintEnd_toStartOf="@id/text_green"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/seek_red"
         app:maxColor="#00ff00"
-        tools:progress="128"
-        />
+        tools:progress="128" />
 
     <TextView
         android:id="@+id/text_green"
@@ -75,27 +65,23 @@
         android:textSize="@dimen/mm2d_cc_color_text"
         app:layout_constraintBottom_toBottomOf="@id/seek_green"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/seek_green"
         app:layout_constraintTop_toTopOf="@id/seek_green"
-        tools:ignore="HardcodedText,SpUsage"
-        />
+        tools:ignore="HardcodedText,SpUsage" />
 
     <net.mm2d.color.chooser.element.ColorSliderView
         android:id="@+id/seek_blue"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/mm2d_cc_page_margin"
-        android:paddingTop="@dimen/mm2d_cc_seek_padding"
-        android:paddingBottom="@dimen/mm2d_cc_seek_padding"
         app:alphaMode="false"
         app:baseColor="#000000"
-        app:layout_constrainedWidth="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/text_blue"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/seek_green"
         app:maxColor="#0000ff"
-        tools:progress="128"
-        />
+        tools:progress="128" />
 
     <TextView
         android:id="@+id/text_blue"
@@ -110,7 +96,7 @@
         android:textSize="@dimen/mm2d_cc_color_text"
         app:layout_constraintBottom_toBottomOf="@id/seek_blue"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/seek_blue"
         app:layout_constraintTop_toTopOf="@id/seek_blue"
-        tools:ignore="HardcodedText,SpUsage"
-        />
+        tools:ignore="HardcodedText,SpUsage" />
 </merge>

--- a/app/src/main/res/layout/pref_shadow.xml
+++ b/app/src/main/res/layout/pref_shadow.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:paddingHorizontal="@dimen/dialog_padding_horizontal"
-    android:paddingVertical="@dimen/dialog_padding_vertical">
+    android:paddingVertical="@dimen/dialog_padding_vertical"
+    tools:layout_width="wrap_content">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -19,23 +21,25 @@
 
         <rocks.tbog.tblauncher.ui.CustomizeShadowView
             android:id="@+id/viewXY"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal" />
 
         <TextView
             android:id="@+id/textValueXY"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-        android:text="@string/value_float_xy"
-        android:textColor="?android:attr/textColorPrimary" />
+            android:text="@string/value_float_xy"
+            android:textAlignment="center"
+            android:textColor="?android:attr/textColorPrimary" />
 
-    <TextView
-        android:id="@android:id/text2"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingTop="10dp"
-        android:text="@string/shadow_radius"
-        android:textColor="?android:attr/textColorPrimary" />
+        <TextView
+            android:id="@android:id/text2"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="10dp"
+            android:text="@string/shadow_radius"
+            android:textColor="?android:attr/textColorPrimary" />
 
         <SeekBar
             android:id="@+id/seekBar"
@@ -51,4 +55,4 @@
             android:textColor="?android:attr/textColorPrimary" />
 
     </LinearLayout>
-</ScrollView>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/values-h400dp/dimens.xml
+++ b/app/src/main/res/values-h400dp/dimens.xml
@@ -17,7 +17,6 @@
 
     <dimen name="mm2d_cc_panel_height">360dp</dimen>
     <dimen name="mm2d_cc_palette_cell_height">48dp</dimen>
-    <dimen name="mm2d_cc_seek_padding">4dp</dimen>
     <dimen name="mm2d_cc_panel_margin">8dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -42,8 +42,7 @@
     <dimen name="widget_preview_width">128dp</dimen>
     <dimen name="widget_preview_height">64dp</dimen>
     <dimen name="widget_preview_padding_vertical">5dp</dimen>
-    
-    <dimen name="mm2d_cc_seek_padding">2dp</dimen>
+
     <dimen name="mm2d_cc_sample_radius">5dp</dimen>
     <dimen name="mm2d_cc_sample_frame">2dp</dimen>
     <dimen name="mm2d_cc_sample_shadow">1dp</dimen>


### PR DESCRIPTION
* [x] make shadow preview smaller to allow scrolling
* [x] stop loading animation from clipping. It was happening in landscape for the color picker dialog.
* [x] fix RGB sliders from the color picker that clip in landscape
* [x] fix HSV sample circle clipping when padding decreases (happens on small devices)